### PR TITLE
docs: fix simple typo, succint -> succinct

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ factorial -> int (int n)
 print (factorial (5))
 ```
 
-You can also write succint one liner verbs like the one below which gives the nth Fibonacci number:
+You can also write succinct one liner verbs like the one below which gives the nth Fibonacci number:
 
 ```
 fib -> int(int n) = (n <= 1).tf (n, fib(n-1) + fib(n-2))

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -49,7 +49,7 @@ The Python language equivalent of this would be:
 
 If the user hasn't supplied an argument, it just prints the usage. As Rix has no keywords, `if`, `else` and `for` are also verbs.
 
-How can we make a more succint version of our Fibonacci program?
+How can we make a more succinct version of our Fibonacci program?
 ----------------------------------------------------------------
 
 We can replace the standard `fib` function above with a single expression function (SEF):


### PR DESCRIPTION
There is a small typo in README.md, doc/tutorial.md.

Should read `succinct` rather than `succint`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md